### PR TITLE
Fix chapter status and content saving

### DIFF
--- a/frontend/src/api/course.js
+++ b/frontend/src/api/course.js
@@ -136,7 +136,9 @@ export function createCourseAPI(data) {
           duration: Number(chapter.duration) || 0,
           content: chapter.content || '',
           videoUrl: chapter.videoUrl || '',
-          contentUrl: chapter.contentUrl || chapter.videoUrl || '',
+          // 将文本内容映射到后端的 contentUrl 字段
+          contentUrl: chapter.content || chapter.contentUrl || chapter.videoUrl || '',
+          status: typeof chapter.status === 'number' ? chapter.status : 0,
 
           // 可选字段
           isFree: Boolean(chapter.isFree),
@@ -209,7 +211,9 @@ export function updateCourseAPI(courseId, data) {
         duration: chapter.duration || 0,
         content: chapter.content || '',
         videoUrl: chapter.videoUrl || '',
-        contentUrl: chapter.contentUrl || chapter.videoUrl || '',
+        // 将文本内容映射到后端的 contentUrl 字段
+        contentUrl: chapter.content || chapter.contentUrl || chapter.videoUrl || '',
+        status: typeof chapter.status === 'number' ? chapter.status : 0,
         isFree: Boolean(chapter.isFree),
         requirements: chapter.requirements || '',
         learningObjectives: chapter.learningObjectives || '',
@@ -284,7 +288,9 @@ export function createChapterAPI(courseId, data) {
       sortOrder: data.sortOrder || data.order || 1,
       content: data.content || '',
       videoUrl: data.videoUrl || '',
-      contentUrl: data.contentUrl || '',
+      // 文本内容映射到后端字段
+      contentUrl: data.content || data.contentUrl || '',
+      status: typeof data.status === 'number' ? data.status : 0,
       materialUrls: data.materialUrls || '',
       isFree: Boolean(data.isFree),
       requirements: data.requirements || '',
@@ -306,7 +312,9 @@ export function updateChapterAPI(courseId, chapterId, data) {
       sortOrder: data.sortOrder || data.order || 1,
       content: data.content || '',
       videoUrl: data.videoUrl || '',
-      contentUrl: data.contentUrl || '',
+      // 文本内容映射到后端字段
+      contentUrl: data.content || data.contentUrl || '',
+      status: typeof data.status === 'number' ? data.status : 0,
       materialUrls: data.materialUrls || '',
       isFree: Boolean(data.isFree),
       requirements: data.requirements || '',

--- a/frontend/src/components/ChapterForm.vue
+++ b/frontend/src/components/ChapterForm.vue
@@ -276,7 +276,7 @@ const initFormData = (data) => {
     title: data.title || '',
     description: data.description || '',
     chapterType: data.chapterType || data.type || 'document',
-    content: data.content || '',
+    content: data.content || data.contentUrl || '',
     duration: data.duration || 0,
     order: data.order || (props.chapterIndex + 1) || 1,
     status: data.status || 0,

--- a/frontend/src/components/CourseForm.vue
+++ b/frontend/src/components/CourseForm.vue
@@ -467,7 +467,7 @@ const processChaptersData = (chapters) => {
       order: chapter.order || chapter.sortOrder || chapter.sort_order || (index + 1),
 
       duration: chapter.duration || 0,
-      content: chapter.content || '',
+      content: chapter.content || chapter.contentUrl || chapter.content_url || '',
 
       // 🔧 处理内容和视频URL
       videoUrl: chapter.videoUrl || chapter.video_url || '',
@@ -537,6 +537,7 @@ const addChapter = () => {
     content: '',
     videoUrl: '',
     contentUrl: '',
+    status: 0,
     requirements: '',
     learningObjectives: '',
     materialUrls: '',


### PR DESCRIPTION
## Summary
- map `contentUrl` and include `status` when creating/updating chapters
- load chapter content from `contentUrl`
- ensure new chapters have status field

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*
- `mvn test` *(fails: command not found: mvn)*

------
https://chatgpt.com/codex/tasks/task_e_687f5083b528832cb74e2a597f381720