### PR TITLE
Add UserManagement route and menu

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -87,7 +87,19 @@ const routes = [
           title: '管理后台',
           icon: '⚙️',
           roles: ['ADMIN'] // 仅管理员可访问
-        }
+        },
+        children: [
+          {
+            path: 'user-management',
+            name: 'UserManagement',
+            component: () => import('@/views/UserManagement.vue'),
+            meta: {
+              title: '用户管理',
+              icon: '👤',
+              roles: ['ADMIN']
+            }
+          }
+        ]
       }
     ]
   },
@@ -131,6 +143,12 @@ export const generateMenus = (userRole) => {
       path: '/admin',
       title: '管理后台',
       icon: '⚙️',
+      hidden: userRole !== 'ADMIN'
+    },
+    {
+      path: '/admin/user-management',
+      title: '用户管理',
+      icon: '👤',
       hidden: userRole !== 'ADMIN'
     }
   ]


### PR DESCRIPTION
## Summary
- register `/admin/user-management` as a child route under `/admin`
- add new admin-only menu item for User Management

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687f716a095c832cac95ed963e85a9a4