### PR TITLE
Fix Admin child view rendering

### DIFF
--- a/frontend/src/views/Admin.vue
+++ b/frontend/src/views/Admin.vue
@@ -235,6 +235,7 @@
         </div>
       </el-card>
     </div>
+    <router-view />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- add missing `<router-view />` to Admin page so sub-routes render

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_687f74d8a2b8832ca7e93465a2fe1685