### PR TITLE
Add basic user and role APIs

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/controller/RoleController.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/controller/RoleController.java
@@ -1,0 +1,27 @@
+package com.example.smarttrainingsystem.controller;
+
+import com.example.smarttrainingsystem.common.Result;
+import com.example.smarttrainingsystem.dto.RoleDTO;
+import com.example.smarttrainingsystem.service.RoleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/roles")
+@RequiredArgsConstructor
+@Slf4j
+public class RoleController {
+
+    private final RoleService roleService;
+
+    @GetMapping
+    public Result<List<RoleDTO.Option>> getRoles() {
+        List<RoleDTO.Option> options = roleService.getAllRoles();
+        return Result.success("获取角色列表成功", options);
+    }
+}

--- a/backend/src/main/java/com/example/smarttrainingsystem/controller/UserController.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.example.smarttrainingsystem.controller;
+
+import com.example.smarttrainingsystem.common.Result;
+import com.example.smarttrainingsystem.dto.UserDTO;
+import com.example.smarttrainingsystem.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Slf4j
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public Result<Map<String, Object>> getUsers(
+            @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
+            @RequestParam(value = "pageSize", required = false, defaultValue = "10") Integer pageSize,
+            @RequestParam(value = "role", required = false) String role,
+            @RequestParam(value = "keyword", required = false) String keyword) {
+
+        Page<UserDTO.ListItem> users = userService.getUsers(page, pageSize, role, keyword);
+        Map<String, Object> resp = new HashMap<>();
+        resp.put("data", users.getContent());
+        resp.put("total", users.getTotalElements());
+        return Result.success("获取用户列表成功", resp);
+    }
+}

--- a/backend/src/main/java/com/example/smarttrainingsystem/dto/RoleDTO.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/dto/RoleDTO.java
@@ -1,0 +1,15 @@
+package com.example.smarttrainingsystem.dto;
+
+import lombok.Data;
+
+/**
+ * 角色下拉选项DTO
+ */
+public class RoleDTO {
+
+    @Data
+    public static class Option {
+        private String label;
+        private String value;
+    }
+}

--- a/backend/src/main/java/com/example/smarttrainingsystem/dto/UserDTO.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/dto/UserDTO.java
@@ -1,0 +1,25 @@
+package com.example.smarttrainingsystem.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 用户管理相关DTO
+ */
+public class UserDTO {
+
+    /**
+     * 用户列表项
+     */
+    @Data
+    public static class ListItem {
+        private String id;
+        private String username;
+        private String name;
+        private String email;
+        private String role;
+        private String status;
+        private LocalDateTime lastLogin;
+    }
+}

--- a/backend/src/main/java/com/example/smarttrainingsystem/service/RoleService.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/service/RoleService.java
@@ -1,0 +1,31 @@
+package com.example.smarttrainingsystem.service;
+
+import com.example.smarttrainingsystem.dto.RoleDTO;
+import com.example.smarttrainingsystem.entity.Role;
+import com.example.smarttrainingsystem.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoleService {
+
+    private final RoleRepository roleRepository;
+
+    @Transactional(readOnly = true)
+    public List<RoleDTO.Option> getAllRoles() {
+        List<Role> roles = roleRepository.findAllActiveRoles();
+        return roles.stream().map(r -> {
+            RoleDTO.Option opt = new RoleDTO.Option();
+            opt.setLabel(r.getRoleName());
+            opt.setValue(r.getRoleCode());
+            return opt;
+        }).collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/example/smarttrainingsystem/service/UserService.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/service/UserService.java
@@ -1,0 +1,55 @@
+package com.example.smarttrainingsystem.service;
+
+import com.example.smarttrainingsystem.dto.UserDTO;
+import com.example.smarttrainingsystem.entity.Role;
+import com.example.smarttrainingsystem.entity.User;
+import com.example.smarttrainingsystem.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 分页查询用户
+     */
+    @Transactional(readOnly = true)
+    public Page<UserDTO.ListItem> getUsers(Integer page, Integer pageSize, String role, String keyword) {
+        int p = page != null && page > 0 ? page - 1 : 0;
+        int size = pageSize != null && pageSize > 0 ? pageSize : 10;
+        Pageable pageable = PageRequest.of(p, size);
+
+        Page<User> result = userRepository.searchUsers(
+                StringUtils.hasText(keyword) ? keyword : null,
+                null,
+                StringUtils.hasText(role) ? role : null,
+                pageable);
+
+        return result.map(this::convertToListItem);
+    }
+
+    private UserDTO.ListItem convertToListItem(User user) {
+        UserDTO.ListItem dto = new UserDTO.ListItem();
+        dto.setId(user.getId());
+        dto.setUsername(user.getUsername());
+        dto.setName(user.getRealName() != null ? user.getRealName() : user.getNickname());
+        dto.setEmail(user.getEmail());
+        dto.setStatus(Boolean.TRUE.equals(user.getActive()) ? "active" : "inactive");
+        dto.setLastLogin(user.getEffectiveLastLoginTime());
+        if (user.getRoles() != null && !user.getRoles().isEmpty()) {
+            Role first = user.getRoles().iterator().next();
+            dto.setRole(first.getRoleCode());
+        }
+        return dto;
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserController` and `RoleController`
- create `UserService` and `RoleService`
- provide simple `UserDTO` and `RoleDTO`
- implement `/api/users` and `/api/roles` endpoints

## Testing
- `mvn test` *(fails: mvn not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f7736769c832cb74ca50c4be64660