### PR TITLE
Fix UserManagement user list parsing

### DIFF
--- a/frontend/src/views/UserManagement.vue
+++ b/frontend/src/views/UserManagement.vue
@@ -268,9 +268,9 @@ function switchTab(name) {
 async function fetchUsers() {
   try {
     const res = await getUsersAPI(query)
-    const list = res.records || res.data || res.items || res.list || []
-    users.value = list
-    total.value = res.total || list.length
+    const { records = [], total: totalCount = 0 } = res.data || {}
+    users.value = records
+    total.value = totalCount
   } catch (e) {
     ElMessage.error('获取用户列表失败')
   }


### PR DESCRIPTION
## Summary
- handle nested user list structure when fetching users

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_687f7a55512c832cad11fdac48615cfa