### PR TITLE
Fix UserRole UUID generation

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/entity/UserRole.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/entity/UserRole.java
@@ -82,10 +82,10 @@ public class UserRole {
     private User assignedByUser;
 
     /**
-     * 在持久化前确保主键存在
+     * 在持久化前生成主键
      */
     @PrePersist
-    public void prePersist() {
+    public void preInsert() {
         if (this.id == null) {
             this.id = UUID.randomUUID().toString();
         }


### PR DESCRIPTION
## Summary
- ensure UserRole id generated before insert by renaming lifecycle method

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f97571a78832cb569540d649d9a0e