### PR TITLE
Fix department and phone not displayed in edit user modal

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/dto/UserDTO.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/dto/UserDTO.java
@@ -24,6 +24,8 @@ public class UserDTO {
         private String email;
         private String role;
         private String status;
+        private String department;
+        private String phone;
         private LocalDateTime lastLogin;
     }
 

--- a/backend/src/main/java/com/example/smarttrainingsystem/service/UserService.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/service/UserService.java
@@ -137,6 +137,8 @@ public class UserService {
         dto.setName(user.getRealName() != null ? user.getRealName() : user.getNickname());
         dto.setEmail(user.getEmail());
         dto.setStatus(Boolean.TRUE.equals(user.getActive()) ? "active" : "inactive");
+        dto.setDepartment(user.getDepartment());
+        dto.setPhone(user.getPhone());
         dto.setLastLogin(user.getEffectiveLastLoginTime());
         roleRepository.findRolesByUserId(user.getId()).stream().findFirst()
                 .ifPresent(r -> dto.setRole(r.getRoleCode()));


### PR DESCRIPTION
## Summary
- include department & phone fields in `UserDTO.ListItem`
- map department & phone when converting `User` to `ListItem`

## Testing
- `mvn -q test` *(failed: could not resolve dependencies)*
- `npm run lint` *(failed: cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6880422d46fc832c95b55f2ddcd3179c