### PR TITLE
Use env base url in frontend

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=/api

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -2,7 +2,7 @@
 # Vite 环境变量必须以 VITE_ 开头
 
 # 后端API地址
-VITE_APP_BASE_API=http://localhost:8080
+VITE_API_BASE_URL=/api
 
 # 应用标题
 VITE_APP_TITLE=智能培训系统

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=/api

--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -31,7 +31,7 @@ export const useUserStore = defineStore('user', () => {
   // 检查后端状态
   const checkBackendStatus = async () => {
     try {
-      const response = await fetch('http://localhost:8080/api/v1/auth/login', {
+      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/login`, {
         method: 'HEAD',
         timeout: 3000
       })
@@ -49,7 +49,7 @@ export const useUserStore = defineStore('user', () => {
     try {
       console.log('使用真实后端登录:', username)
       
-      const response = await fetch('http://localhost:8080/api/v1/auth/login', {
+      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/frontend/src/utils/request.js
+++ b/frontend/src/utils/request.js
@@ -4,7 +4,7 @@ import { ElMessage } from 'element-plus'
 
 // 创建axios实例
 const request = axios.create({
-  baseURL: 'http://localhost:8080',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 5000,
   headers: {
     'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- remove localhost base URLs from user store
- point axios base URL to `import.meta.env.VITE_API_BASE_URL`
- add `.env`, `.env.production`, `.env.development` with `VITE_API_BASE_URL=/api`

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68807a07e234832cbb2d4ca7dca90e5b