### PR TITLE
Fix empty password submission on user update

### DIFF
--- a/frontend/src/views/UserManagement.vue
+++ b/frontend/src/views/UserManagement.vue
@@ -384,6 +384,9 @@ async function saveUser() {
       ...form,
       role: typeof form.role === 'object' ? form.role.value : form.role
     }
+    if (isEdit.value && (!form.password || form.password.trim() === '')) {
+      delete payload.password
+    }
     if (isEdit.value) {
       await updateUserAPI(form.id, payload)
       ElMessage.success('用户更新成功')


### PR DESCRIPTION
## Summary
- avoid sending empty password during user update

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*
- `npm run format` *(results revert; not committed)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881a3a8279c832c82897ed9fb707e42