### PR TITLE
Add user reset password endpoint

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/controller/UserController.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/controller/UserController.java
@@ -71,4 +71,10 @@ public class UserController {
         userService.deleteUser(id);
         return Result.success("删除用户成功", null);
     }
+
+    @PostMapping("/{id}/reset-password")
+    public Result<?> resetPassword(@PathVariable String id) {
+        userService.resetPassword(id);
+        return Result.success("密码已重置", null);
+    }
 }

--- a/backend/src/main/java/com/example/smarttrainingsystem/service/UserService.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/service/UserService.java
@@ -130,6 +130,15 @@ public class UserService {
         userRepository.deleteById(userId);
     }
 
+    @Transactional
+    public void resetPassword(String userId) {
+        log.info("重置用户密码: {}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(404, "用户不存在"));
+        user.setPassword(passwordEncoder.encode("123456"));
+        userRepository.save(user);
+    }
+
     private UserDTO.ListItem convertToListItem(User user) {
         UserDTO.ListItem dto = new UserDTO.ListItem();
         dto.setId(user.getId());


### PR DESCRIPTION
## Summary
- add REST endpoint for resetting user password
- implement service logic to update password to default

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881a9df2a1c832c94dd94b6a2ba5bfc