### PR TITLE
Implement course publish feature

### DIFF
--- a/frontend/src/api/course.js
+++ b/frontend/src/api/course.js
@@ -241,8 +241,8 @@ export function deleteCourseAPI(courseId) {
 // 发布课程
 export function publishCourseAPI(courseId) {
   return request({
-    url: `/api/v1/courses/${courseId}/publish`,
-    method: 'POST',
+    url: `/api/courses/${courseId}/publish`,
+    method: 'PUT',
   })
 }
 

--- a/frontend/src/views/CourseManagement.vue
+++ b/frontend/src/views/CourseManagement.vue
@@ -215,7 +215,7 @@ import { useUserStore } from '@/stores/user'
 import { useCourse } from '@/composables/useCourse'
 
 // 🔧 添加这行导入
-import { getCourseChaptersAPI } from '@/api/course'
+import { getCourseChaptersAPI, publishCourseAPI } from '@/api/course'
 
 // 状态管理
 const userStore = useUserStore()
@@ -416,8 +416,18 @@ const deleteCourse = async (course) => {
   }
 }
 
-const toggleCourseStatus = (course) => {
-  ElMessage.info('课程状态切换功能开发中')
+const toggleCourseStatus = async (course) => {
+  try {
+    const res = await publishCourseAPI(course.id)
+    if (res.code === 200) {
+      ElMessage.success('发布成功')
+      course.status = 1
+    } else {
+      ElMessage.error(res.message || '发布失败')
+    }
+  } catch (error) {
+    ElMessage.error(error.message || '发布失败')
+  }
 }
 
 const closeCourseModal = () => {


### PR DESCRIPTION
## Summary
- call the new publish endpoint from course API
- hook up the "发布" button in course management page

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6881c881ee1c832c8987884620bb6f4b