### PR TITLE
Add publish course PUT API

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/controller/CourseController.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/controller/CourseController.java
@@ -16,6 +16,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 
 /**
  * 课程API控制器
@@ -26,7 +28,7 @@ import java.util.List;
  */
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/courses")
+@RequestMapping({"/api/v1/courses", "/api/courses"})
 @RequiredArgsConstructor
 @Validated
 @CrossOrigin(origins = "*", maxAge = 3600)
@@ -134,6 +136,22 @@ public class CourseController {
 
         CourseDTO.Response response = courseService.publishCourse(courseId, userId);
         return Result.success(response);
+    }
+
+    /**
+     * 发布课程 (新接口) - 提供给前端PUT方式
+     */
+    @PutMapping("/{courseId}/publish")
+    public ResponseEntity<?> publishCourseByPut(@PathVariable String courseId) {
+        try {
+            boolean success = courseService.publishCourse(courseId);
+            if (success) {
+                return ResponseEntity.ok().build();
+            }
+        } catch (Exception e) {
+            log.error("发布课程失败", e);
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("发布失败");
     }
 
     /**

--- a/backend/src/main/java/com/example/smarttrainingsystem/service/CourseService.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/service/CourseService.java
@@ -214,6 +214,19 @@ public class CourseService {
         return convertToResponse(savedCourse);
     }
 
+    /**
+     * 发布课程 - 简化接口
+     */
+    @Transactional
+    public boolean publishCourse(String courseId) {
+        log.info("发布课程(简化): courseId={}", courseId);
+        return courseRepository.findById(courseId).map(course -> {
+            course.publish();
+            courseRepository.save(course);
+            return true;
+        }).orElse(false);
+    }
+
     // ==================== 课程搜索和筛选 ====================
 
     /**


### PR DESCRIPTION
## Summary
- support both `/api/v1/courses` and `/api/courses` base paths
- add PUT `/api/courses/{courseId}/publish` endpoint
- add simplified `CourseService.publishCourse(String)` for status update

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881ca45e9dc832cbf1509d3f22effa6