### PR TITLE
Fix unpublish course action

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/controller/CourseController.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/controller/CourseController.java
@@ -170,6 +170,22 @@ public class CourseController {
     }
 
     /**
+     * 下架课程 (新接口) - 提供给前端PUT方式
+     */
+    @PutMapping("/{courseId}/unpublish")
+    public ResponseEntity<?> unpublishCourseByPut(@PathVariable String courseId) {
+        try {
+            boolean success = courseService.unpublishCourse(courseId);
+            if (success) {
+                return ResponseEntity.ok().build();
+            }
+        } catch (Exception e) {
+            log.error("下架课程失败", e);
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("下架失败");
+    }
+
+    /**
      * 搜索课程 - 所有已认证用户可访问
      */
     @GetMapping("/search")

--- a/backend/src/main/java/com/example/smarttrainingsystem/service/CourseService.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/service/CourseService.java
@@ -227,6 +227,19 @@ public class CourseService {
         }).orElse(false);
     }
 
+    /**
+     * 下架课程 - 简化接口
+     */
+    @Transactional
+    public boolean unpublishCourse(String courseId) {
+        log.info("下架课程(简化): courseId={}", courseId);
+        return courseRepository.findById(courseId).map(course -> {
+            course.unpublish();
+            courseRepository.save(course);
+            return true;
+        }).orElse(false);
+    }
+
     // ==================== 课程搜索和筛选 ====================
 
     /**

--- a/frontend/src/api/course.js
+++ b/frontend/src/api/course.js
@@ -251,7 +251,7 @@ export function publishCourseAPI(courseId) {
 export function unpublishCourseAPI(courseId) {
   return request({
     url: `/api/v1/courses/${courseId}/unpublish`,
-    method: 'POST',
+    method: 'PUT',
   })
 }
 

--- a/frontend/src/views/CourseManagement.vue
+++ b/frontend/src/views/CourseManagement.vue
@@ -215,7 +215,7 @@ import { useUserStore } from '@/stores/user'
 import { useCourse } from '@/composables/useCourse'
 
 // 🔧 添加这行导入
-import { getCourseChaptersAPI, publishCourseAPI } from '@/api/course'
+import { getCourseChaptersAPI, publishCourseAPI, unpublishCourseAPI } from '@/api/course'
 
 // 状态管理
 const userStore = useUserStore()
@@ -418,15 +418,25 @@ const deleteCourse = async (course) => {
 
 const toggleCourseStatus = async (course) => {
   try {
-    const res = await publishCourseAPI(course.id)
-    if (res && res.status === 200) {
-      ElMessage.success('发布成功')
-      course.status = 1
+    if (course.status === 1) {
+      const res = await unpublishCourseAPI(course.id)
+      if (res.code === 200) {
+        ElMessage.success('下架成功')
+        course.status = 2
+      } else {
+        ElMessage.error(res.message || '下架失败')
+      }
     } else {
-      ElMessage.error('发布失败')
+      const res = await publishCourseAPI(course.id)
+      if (res && res.status === 200) {
+        ElMessage.success('发布成功')
+        course.status = 1
+      } else {
+        ElMessage.error('发布失败')
+      }
     }
   } catch (error) {
-    ElMessage.error(error.message || '发布失败')
+    ElMessage.error(error.message || (course.status === 1 ? '下架失败' : '发布失败'))
   }
 }
 


### PR DESCRIPTION
## Summary
- change unpublish API method to PUT
- call correct API when toggling course status
- expose new simplified unpublish method in backend service
- add PUT endpoint for unpublish

## Testing
- `mvn -q test` *(fails: spring dependencies unavailable)*
- `npm run lint` *(fails: missing eslint)*

------
https://chatgpt.com/codex/tasks/task_e_6881cf7436a4832cb0a3b4079542c793