### PR TITLE
Fix unpublish course message

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/controller/CourseController.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/controller/CourseController.java
@@ -16,6 +16,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 
@@ -177,12 +179,18 @@ public class CourseController {
         try {
             boolean success = courseService.unpublishCourse(courseId);
             if (success) {
-                return ResponseEntity.ok().build();
+                Map<String, Object> body = new HashMap<>();
+                body.put("success", true);
+                body.put("message", "课程已下架");
+                return ResponseEntity.ok(body);
             }
         } catch (Exception e) {
             log.error("下架课程失败", e);
         }
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("下架失败");
+        Map<String, Object> errorBody = new HashMap<>();
+        errorBody.put("success", false);
+        errorBody.put("message", "下架失败");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorBody);
     }
 
     /**

--- a/frontend/src/api/course.js
+++ b/frontend/src/api/course.js
@@ -252,6 +252,7 @@ export function unpublishCourseAPI(courseId) {
   return request({
     url: `/api/v1/courses/${courseId}/unpublish`,
     method: 'PUT',
+    rawResponse: true
   })
 }
 

--- a/frontend/src/composables/useCourse.js
+++ b/frontend/src/composables/useCourse.js
@@ -291,12 +291,12 @@ export function useCourse() {
 
       const response = await unpublishCourseAPI(courseId)
 
-      if (response.code === 200) {
+      if (response.status === 200) {
         ElMessage.success(`课程"${courseName}"下架成功`)
         await loadCourses() // 刷新列表
         return true
       } else {
-        ElMessage.error(response.message || '课程下架失败')
+        ElMessage.error(response.data?.message || '课程下架失败')
         return false
       }
     } catch (error) {

--- a/frontend/src/views/CourseManagement.vue
+++ b/frontend/src/views/CourseManagement.vue
@@ -420,11 +420,11 @@ const toggleCourseStatus = async (course) => {
   try {
     if (course.status === 1) {
       const res = await unpublishCourseAPI(course.id)
-      if (res.code === 200) {
-        ElMessage.success('下架成功')
+      if (res.status === 200) {
+        ElMessage.success(res.data?.message || '下架成功')
         course.status = 2
       } else {
-        ElMessage.error(res.message || '下架失败')
+        ElMessage.error(res.data?.message || '下架失败')
       }
     } else {
       const res = await publishCourseAPI(course.id)


### PR DESCRIPTION
## Summary
- return success info in `PUT /courses/{id}/unpublish`
- use raw HTTP response when unpublishing a course
- adjust course status update logic to rely on HTTP status

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM)*
- `npm test` *(failed: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6881d2f82b2c832c96c5116ae9aec34e