### PR TITLE
Hide admin navigation menu

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -148,13 +148,15 @@ export const generateMenus = (userRole) => {
     path: '/admin',
     title: '管理后台',
     icon: '⚙️',
-    hidden: userRole !== 'ADMIN'
+    // 强制隐藏导航入口，但保留路由权限
+    hidden: true
   },
   {
     path: '/admin/user-management',
     title: '用户管理',
     icon: '👤',
-    hidden: userRole !== 'ADMIN'
+    // 子菜单同样隐藏，仍保留访问能力
+    hidden: true
   }
   ]
 


### PR DESCRIPTION
## Summary
- hide `管理后台` and `用户管理` in generated menus

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6881ddc07a8c832c9bd8f13db3b82060