### PR TITLE
Fix user management menu role visibility

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -155,8 +155,8 @@ export const generateMenus = (userRole) => {
     path: '/admin/user-management',
     title: '用户管理',
     icon: '👤',
-    // 子菜单同样隐藏，仍保留访问能力
-    hidden: true
+    // 子菜单仅在ADMIN角色下显示
+    hidden: !['ADMIN'].includes(userRole)
   }
   ]
 


### PR DESCRIPTION
## Summary
- show the `User Management` menu item only to ADMIN users

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `mvn test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6881df090f6c832c81492c11c6c95dcd