### PR TITLE
Fix upload success callback for chapters

### DIFF
--- a/frontend/src/components/CourseForm.vue
+++ b/frontend/src/components/CourseForm.vue
@@ -756,7 +756,7 @@ const handleChapterUpload = async (options) => {
       chapterForm.value.mediaUrl = url
       chapterForm.value.videoUrl = url
       chapterMediaFileList.value = [{ name: file.name, url }]
-      if (options.onSuccess) options.onSuccess(res)
+      if (options.onSuccess) options.onSuccess(res.data || res, file)
       ElMessage.success('文件上传成功')
     } else {
       ElMessage.error('文件上传失败')


### PR DESCRIPTION
## Summary
- correct the custom upload callback in `CourseForm` to notify Element Plus about successful chapter media uploads

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*
- `npm run lint` *(fails: cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_688347c4883c832c8fd107114c55e650