### PR TITLE
Fix chapter count on course cards

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/dto/CourseDTO.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/dto/CourseDTO.java
@@ -1,6 +1,7 @@
 package com.example.smarttrainingsystem.dto;
 
 import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.*;
@@ -174,6 +175,7 @@ public class CourseDTO {
         private List<CourseChapterDTO.Response> chapters;
 
         // 统计信息
+        @JsonProperty("chapterCount")
         private Integer totalChapters;
         private Integer totalDuration;
 

--- a/backend/src/main/java/com/example/smarttrainingsystem/service/CourseService.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/service/CourseService.java
@@ -580,8 +580,10 @@ public class CourseService {
         item.setVideoList(convertVideoInfoList(course.getVideoInfoList()));
 
         // 设置统计信息
+        int chapterCount = courseChapterRepository.countByCourseId(course.getId());
+        item.setTotalChapters(chapterCount);
+
         if (course.getChapters() != null) {
-            item.setTotalChapters(course.getChapters().size());
             item.setTotalDuration(course.getChapters().stream()
                     .mapToInt(chapter -> chapter.getDuration() != null ? chapter.getDuration() : 0)
                     .sum());


### PR DESCRIPTION
## Summary
- compute chapter totals in `CourseService.convertToListItem`
- expose chapter totals via `chapterCount` field in `CourseDTO.ListItem`

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68835d5977a4832cb54fc0656804b41b