### PR TITLE
Update my courses API endpoint

### DIFF
--- a/frontend/src/api/userStudy.js
+++ b/frontend/src/api/userStudy.js
@@ -2,7 +2,7 @@ import request from '@/utils/request'
 
 export function getMyCourses() {
   return request({
-    url: '/api/v1/user-study/courses',
+    url: '/api/v1/user-study/my-courses',
     method: 'GET'
   })
 }

--- a/frontend/src/views/Courses.vue
+++ b/frontend/src/views/Courses.vue
@@ -357,7 +357,7 @@ onMounted(async () => {
         prerequisite: c.prerequisite || '',
         icon: c.icon || randomIcon(),
         bg: c.bg || randomBg(),
-        favorite: c.favorite ?? false,
+        favorite: c.isFavorited ?? false,
       }))
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- call `/api/v1/user-study/my-courses` to load personal course list
- map `isFavorited` field from API

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6885a45f4b00832c96235d07b385085b