### PR TITLE
Add start learning button on course cards

### DIFF
--- a/frontend/src/views/CourseManagement.vue
+++ b/frontend/src/views/CourseManagement.vue
@@ -125,6 +125,7 @@
           </div>
 
           <div class="course-actions">
+            <button class="btn btn-primary" @click="startLearning">开始学习</button>
             <el-button size="small" @click="viewCourse(course.id)">
               <el-icon><View /></el-icon>
               详情
@@ -207,6 +208,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import {
   Plus, Search, Edit, Delete, View, User, Star, Document
 } from '@element-plus/icons-vue'
+import { useRouter } from 'vue-router'
 
 // 导入组件
 import CourseForm from '@/components/CourseForm.vue'
@@ -219,6 +221,10 @@ import { getCourseChaptersAPI, publishCourseAPI, unpublishCourseAPI } from '@/ap
 
 // 状态管理
 const userStore = useUserStore()
+const router = useRouter()
+const startLearning = () => {
+  router.push('/learning/product-basic')
+}
 
 // 使用组合式函数
 const {


### PR DESCRIPTION
## Summary
- add a "开始学习" button to each course card
- route to `/learning/product-basic` when clicked

## Testing
- `npm run lint` *(fails: cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6885b3e91748832ca68754e4acc5717c