### PR TITLE
Fix media URL to stream video

### DIFF
--- a/frontend/src/views/LearningPage.vue
+++ b/frontend/src/views/LearningPage.vue
@@ -177,7 +177,7 @@ const route = useRoute()
 const resolveMediaUrl = (url) => {
   if (!url) return ''
   if (url.startsWith('http')) return url
-  return `http://localhost:3000${url}`
+  return `http://localhost:3000${url.replace('/api/v1/files/course/videos/', '/api/v1/media/video/')}`
 }
 
 // 响应式数据


### PR DESCRIPTION
## Summary
- resolve video URLs to use streaming API instead of download path

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885e4291ee0832c9e43cce9958e18e2