### PR TITLE
Fix video stream auth

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                         .antMatchers("/api/v1/test/**").permitAll()
                         .antMatchers("/api/v1/debug/public").permitAll()
                         .antMatchers("/api/v1/files/**").permitAll()  // 允许文件访问
+                        .antMatchers("/api/v1/media/video/**").permitAll() // 视频流接口匿名访问
                         // 其他接口需要认证，但暂时放宽要求
                         .anyRequest().permitAll()  // 暂时允许所有请求，但JWT过滤器仍会处理
                 )


### PR DESCRIPTION
## Summary
- allow anonymous access to `/api/v1/media/video/**`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6885ec70e6b4832c863dc1e600b1ba24