### PR TITLE
Add auth header for course cover upload

### DIFF
--- a/frontend/src/components/CourseForm.vue
+++ b/frontend/src/components/CourseForm.vue
@@ -300,7 +300,13 @@ const handleCoverUpload = async ({ file, onSuccess, onError }) => {
   const formData = new FormData()
   formData.append('file', file)
   try {
-    const res = await axios.post('/api/v1/upload/course-cover', formData)
+    const token = localStorage.getItem('token')
+    const res = await axios.post('/api/v1/upload/course-cover', formData, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'multipart/form-data'
+      }
+    })
     if (res.data?.url) {
       form.coverImage = res.data.url
       coverFileList.value = [


### PR DESCRIPTION
## Summary
- ensure Authorization header is included when uploading course cover

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_688752104928832cb94c7c9247c08c81