### PR TITLE
Fix course cover display on edit

### DIFF
--- a/frontend/src/components/CourseForm.vue
+++ b/frontend/src/components/CourseForm.vue
@@ -247,24 +247,27 @@ watch(
   () => props.courseData,
   async (newVal) => {
     if (newVal) {
+      const cover =
+        newVal.coverImage || newVal.coverImageUrl || newVal.coverUrl || ''
+
       Object.assign(form, {
         title: newVal.title || '',
         category: newVal.category || '',
         difficulty: newVal.difficulty || 'beginner',
-        coverImage: newVal.coverImage || newVal.coverImageUrl || '',
+        coverImage: cover,
         description: newVal.description || '',
         chapters: newVal.chapters || [],
         isRequired: newVal.isRequired || false,
         tags: newVal.tags || []
       })
 
-      if (newVal.coverImage || newVal.coverImageUrl) {
+      if (newVal.coverImage || newVal.coverImageUrl || newVal.coverUrl) {
+        const coverUrl =
+          newVal.coverImage || newVal.coverImageUrl || newVal.coverUrl
         coverFileList.value = [
           {
-            name: (newVal.coverImage || newVal.coverImageUrl)
-              .split('/')
-              .pop(),
-            url: newVal.coverImage || newVal.coverImageUrl
+            name: coverUrl.split('/').pop(),
+            url: coverUrl
           }
         ]
       } else if (props.isEditing && newVal.id) {


### PR DESCRIPTION
## Summary
- properly initialize cover image file list when editing a course

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_688754b90240832ca61d9c2cfbca8d24