### PR TITLE
Add online document preview

### DIFF
--- a/backend/src/main/java/com/example/smarttrainingsystem/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                         .antMatchers("/api/v1/debug/public").permitAll()
                         .antMatchers("/api/v1/files/**").permitAll()  // 允许文件访问
                         .antMatchers("/api/v1/media/video/**").permitAll() // 视频流接口匿名访问
+                        .antMatchers("/api/v1/media/document/**").permitAll() // 文档流接口匿名访问
                         // 其他接口需要认证，但暂时放宽要求
                         .anyRequest().permitAll()  // 暂时允许所有请求，但JWT过滤器仍会处理
                 )

--- a/backend/src/main/java/com/example/smarttrainingsystem/controller/DocumentStreamController.java
+++ b/backend/src/main/java/com/example/smarttrainingsystem/controller/DocumentStreamController.java
@@ -1,0 +1,74 @@
+package com.example.smarttrainingsystem.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * 文档流控制器
+ * 提供课程文档的在线预览接口，设置 Content-Disposition 为 inline
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/media")
+public class DocumentStreamController {
+
+    @Value("${app.upload.path:/uploads}")
+    private String uploadPath;
+
+    /**
+     * 文档流式访问接口
+     * 路径: /api/v1/media/document/{userId}/{year}/{month}/{filename}
+     */
+    @GetMapping("/document/{userId}/{year}/{month}/{filename}")
+    public void streamDocument(@PathVariable String userId,
+                               @PathVariable String year,
+                               @PathVariable String month,
+                               @PathVariable String filename,
+                               HttpServletResponse response) {
+        Path filePath = Paths.get(uploadPath)
+                .resolve("course/documents")
+                .resolve(userId)
+                .resolve(year)
+                .resolve(month)
+                .resolve(filename);
+
+        if (!Files.exists(filePath) || !Files.isReadable(filePath)) {
+            log.warn("请求的文档文件不存在或不可读: {}", filePath);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        String contentType;
+        try {
+            contentType = Files.probeContentType(filePath);
+        } catch (IOException e) {
+            contentType = null;
+        }
+        if (contentType == null) {
+            contentType = "application/octet-stream";
+        }
+
+        response.setContentType(contentType);
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"");
+
+        try (ServletOutputStream out = response.getOutputStream()) {
+            Files.copy(filePath, out);
+            out.flush();
+        } catch (IOException e) {
+            log.error("文档流输出失败: {}", e.getMessage(), e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/frontend/src/views/LearningPage.vue
+++ b/frontend/src/views/LearningPage.vue
@@ -105,8 +105,8 @@
                 您的浏览器不支持视频播放
               </video>
               <iframe
-                v-else-if="isDocument && resolvedMediaUrl"
-                :src="resolvedMediaUrl"
+                v-else-if="isDocument && documentViewerUrl"
+                :src="documentViewerUrl"
                 class="media-viewer"
                 style="height: 100%; width: 100%; border: none"
               ></iframe>
@@ -216,7 +216,11 @@ const resolveMediaUrl = (url) => {
     finalUrl = `${API_BASE}${path.replace('/api/v1/files/course/videos/', '/api/v1/media/video/')}`
   } else if (path.startsWith('/api/v1/files/course/video/')) {
     finalUrl = `${API_BASE}${path.replace('/api/v1/files/course/video/', '/api/v1/media/video/')}`
+  } else if (path.startsWith('/api/v1/files/course/documents/')) {
+    finalUrl = `${API_BASE}${path.replace('/api/v1/files/course/documents/', '/api/v1/media/document/')}`
   } else if (path.startsWith('/api/v1/media/video/')) {
+    finalUrl = `${API_BASE}${path}`
+  } else if (path.startsWith('/api/v1/media/document/')) {
     finalUrl = `${API_BASE}${path}`
   } else if (path.startsWith('/')) {
     finalUrl = `${API_BASE}${path}`
@@ -261,6 +265,13 @@ const currentLessonData = computed(() => {
 const resolvedMediaUrl = computed(() => getVideoUrl(currentLessonData.value))
 const isVideo = computed(() => isVideoFile(resolvedMediaUrl.value))
 const isDocument = computed(() => isDocumentFile(resolvedMediaUrl.value))
+const documentViewerUrl = computed(() => {
+  if (isDocument.value && resolvedMediaUrl.value) {
+    const encoded = encodeURIComponent(resolvedMediaUrl.value)
+    return `https://docs.google.com/gview?embedded=1&url=${encoded}`
+  }
+  return ''
+})
 
 // 监听视频地址变化，强制重新加载播放器
 watch(


### PR DESCRIPTION
## Summary
- allow anonymous access to new document stream endpoint
- implement `DocumentStreamController` for inline document preview
- resolve document URLs client-side and open via Google Docs viewer

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint' due to offline environment)*
- `mvn -q test` *(fails: Could not resolve dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6888b21a3384832cb53da43e725ccd67